### PR TITLE
feat(Scan.java): fix(plcc.py): refactor(plcc.py):

### DIFF
--- a/src/Std/Scan.java
+++ b/src/Std/Scan.java
@@ -49,7 +49,7 @@ public class Scan implements IScan {
             // System.err.print("s=" + s);
         }
     }
-
+        
     public Token cur() {
         // lazy
         if (tok != null)
@@ -62,7 +62,7 @@ public class Scan implements IScan {
         while (true) {
             fillString(); // get another line if necessary
             if (s == null) {
-                tok = new Token(Token.Val.$EOF, "EOF", lno); // EOF
+                tok = new Token(Token.Val.$EOF, "!EOF", lno); // EOF
                 return tok;
             }
             // s cannot be null here
@@ -94,14 +94,14 @@ public class Scan implements IScan {
                     }
                 }
             }
-            if (valFound == null) { // nothing matches!!
+            if (valFound == null) { // got to $ERROR, so nothing matches!!
                 char ch = s.charAt(start++); // grab the char and advance
                 String sch;
                 if (ch >= ' ' && ch <= '~')
-                    sch = String.format("%c", ch);
+                    sch = String.format("\"%c\"", ch);
                 else
                     sch = String.format("\\u%04x", (int)ch);
-                tok = new Token(Token.Val.$ERROR, sch, lno);
+                tok = new Token(Token.Val.$ERROR, "!ERROR("+sch+")", lno);
                 return tok;
             }
             start = matchEnd; // start of next token match
@@ -120,7 +120,7 @@ public class Scan implements IScan {
     }
 
     public void put(Token t) {
-        throw new RuntimeException("Scan class: put not implemented");
+            throw new RuntimeException("\n>>> Scan class: put not implemented");
     }
 
     public Token match(Token.Val v, Trace trace) {
@@ -128,11 +128,16 @@ public class Scan implements IScan {
         Token.Val vv = t.val;
         if (v == vv) {
             if (trace != null)
-            trace.print(t);
+                trace.print(t);
             adv();
         } else {
+            String str;
+            if (vv == Token.Val.$ERROR)
+                str = t.toString();
+            else
+                str = vv.toString();
             throw new RuntimeException
-                ("match failure: expected token " + v + ", got " + t);
+                ("\n>>> match failure: expected token " + v + ", got " + str);
         }
         return t;
     }
@@ -147,7 +152,7 @@ public class Scan implements IScan {
             String s;
             switch(t.val) {
             case $ERROR:
-                s = String.format("ERROR '%s'", t.str);
+                s = t.str;
                 break;
             default:
                 s = String.format("%s '%s'", t.val.toString(), t.str);

--- a/src/Std/Scan.java
+++ b/src/Std/Scan.java
@@ -49,7 +49,7 @@ public class Scan implements IScan {
             // System.err.print("s=" + s);
         }
     }
-
+        
     public Token cur() {
         // lazy
         if (tok != null)
@@ -120,7 +120,7 @@ public class Scan implements IScan {
     }
 
     public void put(Token t) {
-        throw new RuntimeException("\n>>> Scan class: put not implemented");
+            throw new RuntimeException("\n>>> Scan class: put not implemented");
     }
 
     public Token match(Token.Val v, Trace trace) {

--- a/src/Std/Scan.java
+++ b/src/Std/Scan.java
@@ -49,7 +49,7 @@ public class Scan implements IScan {
             // System.err.print("s=" + s);
         }
     }
-        
+
     public Token cur() {
         // lazy
         if (tok != null)
@@ -120,7 +120,7 @@ public class Scan implements IScan {
     }
 
     public void put(Token t) {
-            throw new RuntimeException("\n>>> Scan class: put not implemented");
+        throw new RuntimeException("\n>>> Scan class: put not implemented");
     }
 
     public Token match(Token.Val v, Trace trace) {

--- a/src/Std/Scan.java
+++ b/src/Std/Scan.java
@@ -49,7 +49,7 @@ public class Scan implements IScan {
             // System.err.print("s=" + s);
         }
     }
-        
+
     public Token cur() {
         // lazy
         if (tok != null)

--- a/src/plcc.py
+++ b/src/plcc.py
@@ -387,8 +387,7 @@ def processRule(line, rno):
     if base == cls:
         deathLNO('base class and derived class names cannot be the same!')
     ruleType = tnt.pop(0)  # either '**=' or '::='
-    rhs = tnt              # a list of all the items to the right
-                           # of the ::= or **= on the line
+    rhs = tnt              # a list of all the items to the right of the ::= or **= on the line
     if ruleType == '**=':  # this is an arbno rule
         if cls:
             deathLNO('arbno rule cannot specify a non base class name')
@@ -403,14 +402,12 @@ def processRule(line, rno):
             sep = sep[1:] # remove the leading '+' from the separator
             if not isTerm(sep):
                 deathLNO('final separator in an arbno rule must be a Terminal')
-            rhs.pop()       # remove separator from the rhs list
+            rhs.pop()     # remove separator from the rhs list
         else:
             sep = None
         # arbno rule has no derived classes, so it's just a base class
-        # saveFields(base, lhs, rhs) # check for duplicate classes,
-        # then map the base to its (lhs, rhs) pair
-        arbno[base] = sep   # mark base as an arbno class with separator sep
-                            # (possibly None)
+        # saveFields(base, lhs, rhs) # check for duplicate classes, then map the base to its (lhs, rhs) pair
+        arbno[base] = sep   # mark base as an arbno class with separator sep (possibly None)
         # next add non-arbno rules to the rule set to simulate arbno rules
         rhsString = ' '.join(rhs)
         if sep:

--- a/src/plcc.py
+++ b/src/plcc.py
@@ -96,6 +96,16 @@ def main():
             argv = argv[1:]
         else:
             break
+
+    # Handle --version option.
+    if 'version' in flags and flags['version']:
+        from pathlib import Path
+        version_file = Path(__file__).resolve().parent / 'VERSION'
+        with open(version_file, 'r') as f:
+            contents = f.read()
+            print("PLCC " + contents.strip())
+        sys.exit(0)
+
     nxt = nextLine()     # nxt is the next line generator
     lex(nxt)    # lexical analyzer generation
     par(nxt)    # LL(1) check and parser generation
@@ -113,7 +123,7 @@ def plccInit():
     for fname in STD:
         flags[fname] = fname
     flags['libplcc'] = LIBPLCC()
-    flags['Token'] = True         
+    flags['Token'] = True
     # behavior-related flags
     flags['PP'] = ''              # preprocessor cmd (e.g., 'cpp -P')
     flags['debug'] = 0            # default debug value
@@ -123,7 +133,7 @@ def plccInit():
     flags['parser'] = True        # create a parser
     flags['semantics'] = True     # create semantics routines
     flags['nowrite'] = False      # when True, produce *no* file output
-    
+
 def lex(nxt):
     # print('=== lexical specification')
     for line in nxt:
@@ -227,7 +237,7 @@ def lexFinishUp():
     except FileExistsError:
         pass
     except:
-        death(std + ': cannot access directory') 
+        death(std + ': cannot access directory')
     fname = '{}/{}'.format(dst, 'Token.java')
     try:
         tokenFile = open(fname, 'w')
@@ -343,7 +353,7 @@ def parFinishUp():
 
     if getFlag('nowrite'):
         return
-    # copy the Std parser-related files 
+    # copy the Std parser-related files
     dst = getFlag('destdir')
     libplcc = getFlag('libplcc')
     std = libplcc + '/Std'
@@ -354,7 +364,7 @@ def parFinishUp():
                 shutil.copy('{}/{}.java'.format(std, fname), '{}/{}.java'.format(dst, fname))
             except:
                 death('Failure copying {} from {} to {}'.format(fname, std, dst))
-    
+
     # build parser stub classes
     buildStubs()
     # build the PLCC$Start.java file from the start symbol
@@ -504,7 +514,7 @@ def checkLL1():
         if len(form) == 0:         # the form is empty, so it only derives Null
             return {'Null'}
         tnt = form[0]              # get the item at the start of the sentential form
-        if isTerm(tnt): 
+        if isTerm(tnt):
             return {tnt}           # the form starts with a terminal, which is clearly its only first set item
         # tnt must be a nonterm -- get the first set for this and add it to our current set
         f = first[tnt]             # get the current first set for tnt (=form[0])
@@ -576,7 +586,7 @@ def checkLL1():
     if debug('[checkLL1] nonterm switch sets:'):
         for nt in switch:
             debug('[checkLL1] {} => {}'.format(nt, switch[nt]))
-    
+
     # finally check for LL(1)
     for nt in switch:
         allTerms = set()
@@ -586,7 +596,7 @@ def checkLL1():
             if s:
                 death('''\
 not LL(1):
-term(s) {} appears in first sets for more than one rule starting with nonterm {} 
+term(s) {} appears in first sets for more than one rule starting with nonterm {}
 '''.format(' '.join(fst), nt))
             else:
                 allTerms.update(fst)
@@ -733,7 +743,7 @@ def indent(n, iList):
         newList.append('{}{}'.format(indentString, item))
     # print('### str={}'.format(str))
     return newList
-    
+
 def makeParse(cls, rhs):
     args = []
     parseList = []
@@ -976,7 +986,7 @@ def done(msg=''):
 
 def nextLine():
     # create a generator to get the next line in the current input file
-    global Lno, Fname, Line 
+    global Lno, Fname, Line
     for Fname in argv:
         # open the next input file
         f = None # the current open file

--- a/src/plcc.py
+++ b/src/plcc.py
@@ -387,7 +387,8 @@ def processRule(line, rno):
     if base == cls:
         deathLNO('base class and derived class names cannot be the same!')
     ruleType = tnt.pop(0)  # either '**=' or '::='
-    rhs = tnt              # a list of all the items to the right of the ::= or **= on the line
+    rhs = tnt              # a list of all the items to the right
+                           # of the ::= or **= on the line
     if ruleType == '**=':  # this is an arbno rule
         if cls:
             deathLNO('arbno rule cannot specify a non base class name')
@@ -402,12 +403,14 @@ def processRule(line, rno):
             sep = sep[1:] # remove the leading '+' from the separator
             if not isTerm(sep):
                 deathLNO('final separator in an arbno rule must be a Terminal')
-            rhs.pop()     # remove separator from the rhs list
+            rhs.pop()       # remove separator from the rhs list
         else:
             sep = None
         # arbno rule has no derived classes, so it's just a base class
-        # saveFields(base, lhs, rhs) # check for duplicate classes, then map the base to its (lhs, rhs) pair
-        arbno[base] = sep   # mark base as an arbno class with separator sep (possibly None)
+        # saveFields(base, lhs, rhs) # check for duplicate classes,
+        # then map the base to its (lhs, rhs) pair
+        arbno[base] = sep   # mark base as an arbno class with separator sep
+                            # (possibly None)
         # next add non-arbno rules to the rule set to simulate arbno rules
         rhsString = ' '.join(rhs)
         if sep:


### PR DESCRIPTION
SJ: This is effectively three commits in one. I placed feat(Scan.java): first in the subject line as its change to the version number would mask the others.

fix(plcc.py): prevent capture of user-defined non-terminals

   I changed the format of automatically generated nonterminal names
   for repeating rules for LL(1) checking. Originally, for a
   nonterminal name like 'nt', the automatically generated nonterminal
   name was 'nt_aux_' and, for ones with a separator, the separator
   nonterminal name was 'nt_sep_'. Since it is possible (though
   remotely so) for a user to have a grammar rule with a nonterminal
   name of these forms, I changed the separator nonterminal name
   to nt+'#', which cannot possibly be mistaken for a user-generated
   name.

refactor(plcc.py): reduce number of rules generated

   I also simplified the generated rules for a repeating rule
   without a separator with two rules instead of three, and for
   ones with a separator, with four rules instead of five. The
   generated parser code remains exactly the same. The only difference,
   internal only to plcc.py, is how the repeating rules are converted
   to right-recursive non-repeating rules for the purposes of
   checking for LL(1).

feat(Scan.java): improve error messages

   I modified Scan.java so that error tokens -- ones that do not
   match any token specification -- have a string representation
   of the form "!ERROR(...)' where '...' is the offending character
   instead of just $ERROR.

   Except for better error reporting for "bad" tokens, these changes
   do not affect any of the generated code for a language.

Co-authored-by: fosler <fossum@halsum.org>
Co-authored-by: jeh <jeh@cs.rit.edu>