### PR TITLE
feat: optional colon in RHS of rule to pass name

### DIFF
--- a/src/plccmk
+++ b/src/plccmk
@@ -14,7 +14,9 @@ if [ $# -gt 0 ];
 then
         FILES="$@"
 else
-        FILES="${FILE:-grammar}"
+        DEFAULT=spec
+        [ -f "$DEFAULT" ] || DEFAULT=grammar
+        FILES="${FILE:-$DEFAULT}"
 fi
 
 [ -d "$LIB" ] || {


### PR DESCRIPTION
This version allows for optional ":" in annotated class and field names.
I know this may be controversial, but I honestly don't think it's a big
deal: I always wondered why I made the "decision" to use ":' in LHS and
not in the RHS -- to do so was NOT a rational decision on my part, and I
am perfectly happy with making them optional in both situations. This
does not break class notes or even the languages in the Code directory,
so it's not a big deal. I suppose the plcc documentation should say
something about this...

fix: conflicting dummy constructor generation

     ONE '1'
     %
     <one> ::= ONE

With the current version of plcc.py, the dummy constructor conflicts
with the automatically-generated constructor for the One.java class.
Removing the dummy constructor fixes this.

refactor: consolidate to one defang procedure

While taking care of the dummy constructor, I also re-factored the
'defang[g]' procedures, so there is only one general 'defang' procedure.
[The term 'defang' refers to removing the angle brackets (fangs) in
<...> grammar rules. I invented the term, so blame me for the usage.]
The 'defangLHS' procedure handles LHS items in BNF rules, and the
'defangRHS' procedure handles RHS items: the LHS and RHS versions are
slightly different. This refactoring makes the python Java class
generation code a bit tighter, but the Java code that gets generated is
exactly the same as before.

---

Co-authored-by: Timothy Fossum <fossum@halsum.org>

Tim wrote the code and the above comments. I'm just the committer.