### PR TITLE
refactor(ci): fix build failure

### DIFF
--- a/containers/plcc/Dockerfile
+++ b/containers/plcc/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 # Install Python 3
 RUN apk add --no-cache python3~=3
-RUN python3 -m ensurepip
+# RUN python3 -m ensurepip
   # && rm -r /usr/lib/python*/ensurepip \
   # && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
   # && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \

--- a/containers/plcc/Dockerfile
+++ b/containers/plcc/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:3
 # Install Python 3
 RUN apk add --no-cache python3~=3 \
   && python3 -m ensurepip \
-  && pip3 install --upgrade pip setuptools \
+  && pip3 install --break-system-packages --upgrade pip setuptools \
   && rm -r /usr/lib/python*/ensurepip \
   && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
   && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \

--- a/containers/plcc/Dockerfile
+++ b/containers/plcc/Dockerfile
@@ -5,12 +5,12 @@
 FROM alpine:3
 
 # Install Python 3
-RUN apk add --no-cache python3~=3 \
-  && python3 -m ensurepip \
-  && rm -r /usr/lib/python*/ensurepip \
-  && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
-  && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \
-  && rm -r /root/.cache
+RUN apk add --no-cache python3~=3
+RUN python3 -m ensurepip
+  # && rm -r /usr/lib/python*/ensurepip \
+  # && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
+  # && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \
+  # && rm -r /root/.cache
 
 # Install JDK
 RUN apk add --no-cache openjdk17-jdk~=17

--- a/containers/plcc/Dockerfile
+++ b/containers/plcc/Dockerfile
@@ -6,11 +6,6 @@ FROM alpine:3
 
 # Install Python 3
 RUN apk add --no-cache python3~=3
-# RUN python3 -m ensurepip
-  # && rm -r /usr/lib/python*/ensurepip \
-  # && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
-  # && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \
-  # && rm -r /root/.cache
 
 # Install JDK
 RUN apk add --no-cache openjdk17-jdk~=17

--- a/containers/plcc/Dockerfile
+++ b/containers/plcc/Dockerfile
@@ -7,7 +7,6 @@ FROM alpine:3
 # Install Python 3
 RUN apk add --no-cache python3~=3 \
   && python3 -m ensurepip \
-  && pip3 install --break-system-packages --upgrade pip setuptools \
   && rm -r /usr/lib/python*/ensurepip \
   && if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
   && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \


### PR DESCRIPTION
Checks were added to prevent folks from breaking their system's
Python installation by updating it or adding libraries to it.

Our Dockerfile was doing this. So we now stop. We still make
sure that Python 3 is installed. But we don't try to upgrade it
or pip.

In the future, we may want to figure out how to use something
like penv to install a particular version of Python that PLCC will
use, that isn't the system's installation.

Closes #97
