### PR TITLE
test: add bin/test/languages.bash that runs tests in ourPLCC/languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# This is created by bin/test/languages.bash. But should not be committed.
+languages/
+
 # PLCC places generated Java files in directories named Java. Ignore them.
 Java/
 

--- a/bin/test/languages.bash
+++ b/bin/test/languages.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LANGUAGES_VERSION="${LANGUAGES_VERSION:-}"
+cd /tmp
+
+rm -rf languages
+git clone https://github.com/ourPLCC/languages.git
+if [ -n "${LANGUAGES_VERSION}" ] ; then
+    git -C ./languages checkout "${LANGUAGES_VERSION}"
+fi
+languages/bin/test.bash
+rm -rf languages

--- a/docs/Developer.md
+++ b/docs/Developer.md
@@ -211,6 +211,20 @@ bin/test/everything.bash
 bin/test/functionality.bash
 ```
 
+### Test languages
+
+Check if our changes work with ourPLCC/languages:
+
+```bash
+bin/test/languages.bash
+```
+
+Test a specific version (git tag, branch, or commit hash) of ourPLCC/languages:
+
+```bash
+LANGUAGES_VESRION=v1.0.1 bin/test/languages.bash
+```
+
 ### Test other things
 
 To learn what other class of tests you can run...


### PR DESCRIPTION
```
test: add bin/test/languages.bash that runs tests in ourPLCC/languages

Accepts an environment variable LANGUAGES_VERSION. Set this to
a Git tag, branch, or hash to run tests against a specific version of
ourPLCC/languages.
```

---

To test this PR...

1. Open in GitPod
2. Run `bin/test/languages.bash`, it should clone ourPLCC/languages into the root of the project, run its tests, and then delete languages/
3. Run `bin/test/everything.bash`, same as above but all the other tests should run.
4. Run `LANGUAGES_VERSION=30872ce bin/test/languages.bash`, it should checkout 30872ce and then run the tests. Look for a "detached head" message.
5. Run `LANGUAGES_VERSION=30872ce bin/test/everything.bash`. This should also work. You should see that same "detached head" message.
6. Added section to Docs/Developer.md about testing languages.